### PR TITLE
Sync Tag Hostname

### DIFF
--- a/Sync_Tag_Hostname/README.md
+++ b/Sync_Tag_Hostname/README.md
@@ -1,0 +1,2 @@
+# EC2のタグとOSのホストネームを同期してプロンプトに表示します
+AWS Command line Tools


### PR DESCRIPTION
EC2のタグとOSのホスト名を同期させて、プロンプトに表示させます
